### PR TITLE
Add markdown comment characters

### DIFF
--- a/settings/language-weave.cson
+++ b/settings/language-weave.cson
@@ -1,3 +1,11 @@
 '.source.weave':
   'editor':
     'softWrap': false
+'.source.weave.md:not(.code)':
+  editor:
+    commentStart: '<!-- '
+    commentEnd: ' -->'
+'.source.pweave.md:not(.code)':
+  editor:
+    commentStart: '<!-- '
+    commentEnd: ' -->'


### PR DESCRIPTION
Markdown accepts raw html in most implementations. The `<!-- ... -->` notation makes a comment in html, and so it can make a comment in Markdown as well. 

Both the [language-markdown](https://github.com/burodepeper/language-markdown/blob/master/settings/markdown.cson) package and the base [language-gfm](https://github.com/atom/language-gfm/blob/master/settings/gfm.cson) package implement this.