### PR TITLE
add doctest to codeblock

### DIFF
--- a/grammars/weave_md.cson
+++ b/grammars/weave_md.cson
@@ -10,7 +10,7 @@
       'include' : 'source.weave.noweb'
     }
     {
-    'begin': '^([`~]{3,})(?:(?:(?:\\{|\\{\\.|)(julia)(?:;|))|(@(docs|autodocs|ref|meta|index|content|example|repl|eval|setup|raw)))\\s*(?:.*?)(\\}|)\\s*$'
+    'begin': '^([`~]{3,})(?:(?:(?:\\{|\\{\\.|)(julia|jldoctest)(?:;|))|(@(docs|autodocs|ref|meta|index|content|example|repl|eval|setup|raw)))\\s*(?:.*?)(\\}|)\\s*$'
     'beginCaptures':
       '1':
         'name': 'markup.heading.weave.md'


### PR DESCRIPTION
A companion to #19 - I missed `jldoctest` as an option for codeblocks.