### PR TITLE
Sync to Julia-Client's Tool-Bar integration config

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -100,6 +100,7 @@ export function consumeJuliaClient (client) {
 }
 
 export function consumeToolBar (getToolBar) {
+    if (!atom.config.get('julia-client.uiOptions.enableToolBar')) return
     toolbar = getToolBar()
     toolbar.addSpacer()
     toolbar.addButton({


### PR DESCRIPTION
This one-line patch fixes `consumeToolBar` so that it doesn't do anything if `julia-client.uiOptions.enableToolBar` is set to `false`.
