### PR TITLE
Prefer language-markdown grammar over language-gfm

### DIFF
--- a/grammars/pweave_md.cson
+++ b/grammars/pweave_md.cson
@@ -50,10 +50,10 @@ patterns: [
       ]
     }
     {
-      'include': 'source.gfm'
+      'include': 'text.md'
     }
     {
-      'include': 'text.md'
+      'include': 'source.gfm'
     }
 
   ]

--- a/grammars/weave_md.cson
+++ b/grammars/weave_md.cson
@@ -51,9 +51,9 @@
       'end' : '$'
     }
     {
-      'include': 'source.gfm'
+      'include': 'text.md'
     }
     {
-      'include': 'text.md'
+      'include': 'source.gfm'
     }
 ]


### PR DESCRIPTION
This patch changes the order of included grammar used for Weave/Pweave markdown files.

When an user activates both language packages, now the rules from language-gfm are prioritised because it's listed first, and but the rules from language-markdown seems more preferable for many reasons.
For example, commenting yaml options works fine with language-markdown but not in language-gfm, and so on.

When an user deactivated either of them, this patch has no effect.