### PR TITLE
Patch/remove unnecessary statements

### DIFF
--- a/lib/html-preview.js
+++ b/lib/html-preview.js
@@ -1,7 +1,6 @@
 'use babel'
 
-import {$, ScrollView} from 'atom-space-pen-views'
-import { CompositeDisposable } from 'atom'
+import { ScrollView } from 'atom-space-pen-views'
 import fs from 'fs-plus'
 import path from 'path'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -57,7 +57,7 @@ function weave(format) {
     outpath.pop()
     outpath = outpath.join('.') + '.' + format
 
-    let weaveCommand  = ''
+    let weaveCommand  = 'using Weave;'
     weaveCommand += 'try;'
     weaveCommand += `weave("${edpath}", doctype="md2${format}"); 1;`
     weaveCommand += 'catch err;'

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,15 +32,15 @@ function weave(format) {
 
     juliaClient.boot()
 
-    ed = atom.workspace.getActiveTextEditor()
-    pane = atom.workspace.getActivePane()
+    const ed = atom.workspace.getActiveTextEditor()
+    const pane = atom.workspace.getActivePane()
     if (!ed) {
         atom.notifications.addError("No editor selected", {
             description: "Select an editor to weave a file."
         })
         return
     }
-    edpath = ed.getPath()
+    let edpath = ed.getPath()
     if (!edpath) {
         atom.notifications.addError("File is not saved", {
             description: "Please save your file to weave it."
@@ -53,18 +53,18 @@ function weave(format) {
     if (process.platform === 'win32') {
         edpath = edpath.replace(/\\/g, "/")
     }
-    outpath = edpath.split('.')
+    let outpath = edpath.split('.')
     outpath.pop()
     outpath = outpath.join('.') + '.' + format
 
-    weaveCommand  = 'using Weave;'
+    let weaveCommand  = ''
     weaveCommand += 'try;'
     weaveCommand += `weave("${edpath}", doctype="md2${format}"); 1;`
     weaveCommand += 'catch err;'
     weaveCommand += '@error("Weaving failed.", error=err); 0;'
     weaveCommand += 'end'
 
-    evalsimple = juliaClient.import({rpc: ['evalsimple']}).evalsimple
+    const evalsimple = juliaClient.import({rpc: ['evalsimple']}).evalsimple
     evalsimple(weaveCommand).then((res) => {
         if (!atom.config.get('language-weave.showPreview')) return
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,6 @@ export function activate () {
     subs = new CompositeDisposable()
 
     subs.add(atom.workspace.addOpener((uri) => {
-        console.log(uri);
         if (path.extname(uri) === '.html' && uri.startsWith('preview://')) {
             return new HTMLPreviewView(uri)
         }


### PR DESCRIPTION
Patches:
- Remove unnecessary log statements (currently it emits log every time an user opens a file)
- Add identifiers to variables
- Remove unused import statements

I manually checked Weaving to HTML/PDF and previewing the results documents works fine after this patch.
